### PR TITLE
Add digit-grouping helper for download counts

### DIFF
--- a/app/helpers/digit-grouping.js
+++ b/app/helpers/digit-grouping.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+function digitGrouping(value) {
+  value = parseFloat(value);
+  return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+export {
+  digitGrouping
+};
+
+export default Ember.Handlebars.makeBoundHelper(digitGrouping);

--- a/app/templates/packages/list.hbs
+++ b/app/templates/packages/list.hbs
@@ -51,7 +51,7 @@
                 <ul class="list-inline visible-xs list-package-details">
                   <li>Owner: <a target="_blank"
                                 href="{{unbound owner.profileUrl}}">{{unbound owner.name}}</a></li>
-                  <li>Downloads: {{unbound downloadedCount}}</li>
+                  <li>Downloads: {{unbound digit-grouping downloadedCount}}</li>
                   <li>Updated: {{unbound ago modifiedAt "LLLL"}}</li>
                 </ul>
               </td>
@@ -60,7 +60,7 @@
                 <a target="_blank" href="{{unbound owner.profileUrl}}">{{unbound owner.name}}</a>
               </td>
               <td class="cell-downloads hidden-xs">
-                {{unbound downloadedCount}}
+                {{unbound digit-grouping downloadedCount}}
               </td>
               <td class="cell-updated hidden-xs">
                 {{unbound ago modifiedAt "LLLL"}}

--- a/tests/unit/helpers/digit-grouping-test.js
+++ b/tests/unit/helpers/digit-grouping-test.js
@@ -1,0 +1,10 @@
+import {
+  digitGrouping
+} from 'ember-cli-addon-search/helpers/digit-grouping';
+
+module('DigitGroupingHelper');
+
+test('it works', function() {
+  var result = digitGrouping('123456789');
+  equal(result, '123,456,789');
+});


### PR DESCRIPTION
This PR addresses #18 using comma for thousand separators/digit grouping. Also includes a simple unit test.
