### PR TITLE
Ignore packages named like ember-cli-fill-murray-*.

### DIFF
--- a/app/routes/packages/list.js
+++ b/app/routes/packages/list.js
@@ -2,7 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model: function () {
-    return this.store.findAll('package');
+    return this.store.findAll('package').then(function(packages){
+      return packages.reject(function(pkg) {
+        return pkg.get('-name').match(/^ember-cli-fill-murray-/);
+      });
+    });
   },
 
   setupController: function (controller, model) {


### PR DESCRIPTION
There are a lot of packages with this name, they are coming from
people following my book https://leanpub.com/ember-cli-101. It is fine
for them to try stuff and publish to npm but we are polluting
emberaddons, sorry.