### PR TITLE
fix back button

### DIFF
--- a/app/controllers/packages/list.js
+++ b/app/controllers/packages/list.js
@@ -3,9 +3,9 @@ import Ember from 'ember';
 var SROLL_TO_POSITION = 250;
 
 export default Ember.Controller.extend({
-  queryParams: ['query'],
+  queryParams: ['query','page'],
 
-  offset: 0,
+  page: 1,
   limit: 12,
 
   foundCount: 0,
@@ -13,12 +13,8 @@ export default Ember.Controller.extend({
   nextDisabled: Ember.computed.not('hasNextPage'),
   previousDisabled: Ember.computed.not('hasPreviousPage'),
 
-  onQueryChange: function() {
-    this.set('offset', 0);
-  }.observes('query'),
-
   currentPageContent: function() {
-    var offset = this.get('offset'),
+    var page = this.get('page'),
         limit = this.get('limit'),
         query = this.get('query');
 
@@ -31,22 +27,26 @@ export default Ember.Controller.extend({
 
     this.set('foundCount', result.length);
 
-    return result.slice(offset, offset + limit);
-  }.property('offset', 'model', 'query').readOnly(),
+    return result.slice((page - 1) * limit, page * limit);
+  }.property('page', 'model', 'query').readOnly(),
 
   hasPreviousPage: function() {
-    return this.get('offset') !== 0;
-  }.property('offset').readOnly(),
+    return this.get('page') !== 1;
+  }.property('page').readOnly(),
 
   hasNextPage: function() {
-    var offset = this.get('offset'),
+    var page = this.get('page'),
         limit = this.get('limit'),
         length = this.get('foundCount');
 
-    return (offset + limit) < length;
-  }.property('offset', 'limit', 'foundCount').readOnly(),
+    return (page * limit) < length;
+  }.property('page', 'limit', 'foundCount').readOnly(),
 
   actions: {
+    resetPage: function() {
+      this.set('page', 1);
+    },
+
     sortBy: function(by, reverse) {
       var sorted =  this.get('model').sortBy(by);
       if (reverse) { sorted.reverse(); }
@@ -56,7 +56,7 @@ export default Ember.Controller.extend({
     nextPage: function() {
       if (this.get('hasNextPage')) {
         var limit = this.get('limit');
-        this.incrementProperty('offset', limit);
+        this.incrementProperty('page', 1);
         window.scrollTo(0, SROLL_TO_POSITION);
       }
     },
@@ -64,7 +64,7 @@ export default Ember.Controller.extend({
     previousPage: function() {
       if (this.get('hasPreviousPage')) {
         var limit = this.get('limit');
-        this.decrementProperty('offset', limit);
+        this.decrementProperty('page', 1);
         window.scrollTo(0, SROLL_TO_POSITION);
       }
     }

--- a/app/controllers/packages/list.js
+++ b/app/controllers/packages/list.js
@@ -55,16 +55,14 @@ export default Ember.Controller.extend({
 
     nextPage: function() {
       if (this.get('hasNextPage')) {
-        var limit = this.get('limit');
-        this.incrementProperty('page', 1);
+        this.incrementProperty('page');
         window.scrollTo(0, SROLL_TO_POSITION);
       }
     },
 
     previousPage: function() {
       if (this.get('hasPreviousPage')) {
-        var limit = this.get('limit');
-        this.decrementProperty('page', 1);
+        this.decrementProperty('page');
         window.scrollTo(0, SROLL_TO_POSITION);
       }
     }

--- a/app/templates/packages/list.hbs
+++ b/app/templates/packages/list.hbs
@@ -4,7 +4,9 @@
       <div class="col-sm-12">
         {{input type="search"
         value=query
+        placeholder="Filter addons"
         class="form-control search-field"
+        autofocus="autofocus"
         key-press="resetPage"}}
       </div>
     </div>

--- a/app/templates/packages/list.hbs
+++ b/app/templates/packages/list.hbs
@@ -4,10 +4,8 @@
       <div class="col-sm-12">
         {{input type="search"
         value=query
-        placeholder="Filter addons"
         class="form-control search-field"
-        autofocus="autofocus"
-        on="change"}}
+        key-press="resetPage"}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR will add `page` as a query param to the url. Now when you navigate the app, using the `previous` and `next` buttons, you will be able to use your browers `back` and `refresh` button to navigate your history backward without resetting the list offset. When you change the search query however, it will bring you back to "page one" for your new search.

addresses #34 