### PR TITLE
add default query param

### DIFF
--- a/app/controllers/packages/list.js
+++ b/app/controllers/packages/list.js
@@ -5,6 +5,7 @@ var SROLL_TO_POSITION = 250;
 export default Ember.Controller.extend({
   queryParams: ['query','page'],
 
+  query: '',
   page: 1,
   limit: 12,
 


### PR DESCRIPTION
When a user enters a query, and deletes it again, the URL will look like this: http://www.emberaddons.com/?query=

This drives me crazy so i added a default empty query param so that when the value of `query` is empty, the param wont get serialised into the URL.