### PR TITLE
opens author page in new tab

### DIFF
--- a/app/templates/components/em-avatar.hbs
+++ b/app/templates/components/em-avatar.hbs
@@ -1,4 +1,4 @@
-<a href="{{unbound npmURL}}">
+<a href="{{unbound npmURL}}" target="_blank">
   <img src="{{unbound gravatar}}" class="gravatar">
 </a>
 {{em-owner-link user=user}}


### PR DESCRIPTION
At the moment, when you click on a gravatar, you will leave the app, getting redirected to www.npmjs.com/~author-name.

With this PR the authors npm profile page will open in a new tab, as it is the behaviour with every other link on this page.