### PR TITLE
Closes #43. Updated references to npmjs.org to npmjs.com instead

### DIFF
--- a/app/templates/-header.hbs
+++ b/app/templates/-header.hbs
@@ -4,7 +4,7 @@
         <div class="col-xs-12 col-sm-6">
         <h1 class="branding">Ember Addons</h1>
         <div class="header-subtitle">
-          <a href="http://www.charted.co/?%7B%22dataUrl%22%3A%22http%3A%2F%2Fember-addons-server.herokuapp.com%2Fstats.csv%22%2C%22charts%22%3A%5B%7B%22type%22%3A%22line%22%2C%22title%22%3A%22Ember%20Addons%22%2C%22note%22%3A%22This%20chart%20shows%20the%20number%20of%20available%20addons%20for%20ember-cli%20on%20npmjs.org.%20http%3A%2F%2Femberaddons.com%22%7D%5D%7D" class="package-count-link">
+          <a href="http://www.charted.co/?%7B%22dataUrl%22%3A%22http%3A%2F%2Fember-addons-server.herokuapp.com%2Fstats.csv%22%2C%22charts%22%3A%5B%7B%22type%22%3A%22line%22%2C%22title%22%3A%22Ember%20Addons%22%2C%22note%22%3A%22This%20chart%20shows%20the%20number%20of%20available%20addons%20for%20ember-cli%20on%20npmjs.com.%20http%3A%2F%2Femberaddons.com%22%7D%5D%7D" class="package-count-link">
             Listing {{#if packageCount}}{{packageCount}}{{else}}hundreds of{{/if}} packages that extend ember-cli.
           </a>
         </div>

--- a/app/templates/components/em-pkg.hbs
+++ b/app/templates/components/em-pkg.hbs
@@ -1,5 +1,5 @@
 <td class="cell-name">
-  <a href="https://npmjs.org/{{unbound pkg.name}}"
+  <a href="https://npmjs.com/{{unbound pkg.name}}"
      target="_blank"
      class="package-link">{{unbound split-prefix pkg.name}}</a>
   {{#if isNew}}
@@ -10,7 +10,7 @@
   </div>
 </td>
 <td class="cell-gravatar hidden-xs">
-  <a href="https://npmjs.org/~{{unbound user.name}}" target="_blank">
+  <a href="https://npmjs.com/~{{unbound user.name}}" target="_blank">
     <img src="{{unbound user.gravatar}}?s=30&d=retro" class="gravatar">
     {{unbound user.name}}
   </a>


### PR DESCRIPTION
This updates all references to `npmjs.org` to `npmjs.com` instead.

See #43 