### PR TITLE
Do not display boilerplate package descriptions

### DIFF
--- a/app/components/em-pkg.js
+++ b/app/components/em-pkg.js
@@ -10,6 +10,10 @@ export default Ember.Component.extend({
 
   isNew: function () {
     return moment().diff(this.get('pkg.time.created'), 'days') <= 7;
-  }.property('pkg.time.created').readOnly()
+  }.property('pkg.time.created').readOnly(),
+
+  hasDescription: function() {
+    return this.get('pkg.description') !== 'The default blueprint for ember-cli addons.';
+  }.property('pkg.description').readOnly()
 
 });

--- a/app/templates/components/em-pkg.hbs
+++ b/app/templates/components/em-pkg.hbs
@@ -5,9 +5,11 @@
   {{#if isNew}}
     <div class="new-package">NEW</div>
   {{/if}}
-  <div class="description">
-    {{unbound pkg.description}}
-  </div>
+  {{#if hasDescription}}
+    <div class="description">
+      {{unbound pkg.description}}
+    </div>
+  {{/if}}
 </td>
 <td class="cell-gravatar hidden-xs">
   <a href="https://npmjs.org/~{{unbound user.name}}" target="_blank">

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "ember-export-application-global": "^1.0.0",
     "ember-moment": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "4.4.0"
   }
 }


### PR DESCRIPTION
This hides package descriptions that match the [addon blueprint boilerplate](https://github.com/ember-cli/ember-cli/blob/4926167f57a8ede25f94b20e92d06be7f8766915/blueprints/addon/index.js#L10) of "The default blueprint for ember-cli addons."

Unrelated, I changed the `glob` dependency in order to install. Details here: https://github.com/ember-cli/ember-cli/issues/3516