### PR TITLE
Make "Ember Addons" heading a link

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -48,6 +48,10 @@ a span.name-prefix {
   font-size: 50px;
 }
 
+.branding a {
+  color: white;
+}
+
 .header-subtitle {
   color: #6b1210;
 }

--- a/app/templates/-header.hbs
+++ b/app/templates/-header.hbs
@@ -2,7 +2,7 @@
     <div class="container">
       <div class="row">
         <div class="col-xs-12 col-sm-6">
-        <h1 class="branding">Ember Addons</h1>
+        <h1 class="branding">{{#link-to 'application' (query-params page=1 query="")}}Ember Addons{{/link-to}}</h1>
         <div class="header-subtitle">
           <a href="http://www.charted.co/?%7B%22dataUrl%22%3A%22http%3A%2F%2Fember-addons-server.herokuapp.com%2Fstats.csv%22%2C%22charts%22%3A%5B%7B%22type%22%3A%22line%22%2C%22title%22%3A%22Ember%20Addons%22%2C%22note%22%3A%22This%20chart%20shows%20the%20number%20of%20available%20addons%20for%20ember-cli%20on%20npmjs.com.%20http%3A%2F%2Femberaddons.com%22%7D%5D%7D" class="package-count-link">
             Listing {{#if packageCount}}{{packageCount}}{{else}}hundreds of{{/if}} packages that extend ember-cli.

--- a/app/templates/-header.hbs
+++ b/app/templates/-header.hbs
@@ -2,7 +2,7 @@
     <div class="container">
       <div class="row">
         <div class="col-xs-12 col-sm-6">
-        <h1 class="branding">{{#link-to 'application' (query-params page=1 query="")}}Ember Addons{{/link-to}}</h1>
+        <h1 class="branding">{{#link-to 'packages.list' (query-params page=1 query="")}}Ember Addons{{/link-to}}</h1>
         <div class="header-subtitle">
           <a href="http://www.charted.co/?%7B%22dataUrl%22%3A%22http%3A%2F%2Fember-addons-server.herokuapp.com%2Fstats.csv%22%2C%22charts%22%3A%5B%7B%22type%22%3A%22line%22%2C%22title%22%3A%22Ember%20Addons%22%2C%22note%22%3A%22This%20chart%20shows%20the%20number%20of%20available%20addons%20for%20ember-cli%20on%20npmjs.com.%20http%3A%2F%2Femberaddons.com%22%7D%5D%7D" class="package-count-link">
             Listing {{#if packageCount}}{{packageCount}}{{else}}hundreds of{{/if}} packages that extend ember-cli.


### PR DESCRIPTION
Make the 'Ember Addons' heading a link to go "home" to the default list.  Resets the current search and page.

I try to click on that text a few times every day :) 