### PR TITLE
Add liquid-fire animation to project page navigation

### DIFF
--- a/app/components/em-list.js
+++ b/app/components/em-list.js
@@ -4,7 +4,8 @@ import filterByQuery from 'ember-cli-filter-by-query/util/filter';
 
 const {
   Component,
-  computed
+  computed,
+  computed: { readOnly, equal }
 } = Ember;
 
 const QUERY_DEBOUNCE = 300;
@@ -15,12 +16,12 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    this._filterList(this.get('query'));
+    this._filterList(this.get('meta.query'));
   },
 
   didUpdateAttrs() {
     this._super(...arguments);
-    this.get('taskFilterList').perform(this.get('query'));
+    this.get('taskFilterList').perform(this.get('meta.query'));
   },
 
   filteredList: [],
@@ -56,13 +57,12 @@ export default Component.extend({
       return sorted;
     }).readOnly(),
 
-  currentPageContent: computed('page', 'sortedPackages', 'query', function() {
-    const page = this.get('page');
-    const limit = this.get('limit');
+  currentPageContent: computed('sortedPackages.[]', 'meta.{page,limit}', function() {
+    const { page, limit } = this.get('meta');
     return this.get('sortedPackages').slice((page - 1) * limit, page * limit);
   }).readOnly(),
 
-  nothingFound: computed.equal('sortedPackages.length', 0),
+  nothingFound: equal('sortedPackages.length', 0),
 
   actions: {
     sortBy(propertyKey) {

--- a/app/components/em-page.js
+++ b/app/components/em-page.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+export default Component.extend({
+  tagName: 'table',
+  classNames: 'table table-packages',
+
+  actions: {
+    sortBy(...args) {
+      this.sortBy(...args);
+    }
+  }
+});

--- a/app/components/em-pagination.js
+++ b/app/components/em-pagination.js
@@ -6,7 +6,7 @@ const {
 } = Ember;
 
 export default Component.extend({
-  tagName: 'tr',
+  tagName: 'div',
   classNames: ['pagination-row'],
 
   page: 1,

--- a/app/controllers/packages/list.js
+++ b/app/controllers/packages/list.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 
 const {
   Controller,
-  isPresent,
   computed: { readOnly }
 } = Ember;
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -214,8 +214,9 @@ a.sort-button {
 }
 
 
-.pagination-cell {
+.pagination-row {
   text-align: center;
+  margin-bottom: 30px;
 }
 
 .pagination-link,

--- a/app/templates/components/em-list.hbs
+++ b/app/templates/components/em-list.hbs
@@ -1,13 +1,21 @@
-<thead>
-  {{partial "-table-header"}}
-</thead>
+{{#liquid-bind 
+  (hash
+    list=currentPageContent
+    meta=meta
+  ) 
+  class="lf-slider" as |currentState|}}
+  {{em-page
+    list=currentState.list
+    query=currentState.meta.query
 
-<tbody>
-  {{#each currentPageContent key="id" as |pkg|}}
-    {{em-pkg pkg=pkg}}
-  {{else}}
-    <td colspan="6">
-      <p class="not-found">Nothing found for "{{query}}"</p>
-    </td>
-  {{/each}}
-</tbody>
+    sortBy=(action 'sortBy')
+  }}
+{{/liquid-bind}}
+
+{{em-pagination
+  list=sortedPackages
+  page=meta.page
+  limit=meta.limit
+  previous=previous
+  next=next
+}}

--- a/app/templates/components/em-list.hbs
+++ b/app/templates/components/em-list.hbs
@@ -10,12 +10,4 @@
       <p class="not-found">Nothing found for "{{query}}"</p>
     </td>
   {{/each}}
-
-  {{em-pagination
-    list=sortedPackages
-    page=page
-    limit=limit
-    previous=previous
-    next=next
-  }}
 </tbody>

--- a/app/templates/components/em-page.hbs
+++ b/app/templates/components/em-page.hbs
@@ -1,0 +1,13 @@
+<thead>
+  {{partial "-table-header"}}
+</thead>
+
+<tbody>
+  {{#each list key="id" as |pkg|}}
+    {{em-pkg pkg=pkg}}
+  {{else}}
+    <td colspan="6">
+      <p class="not-found">Nothing found for "{{query}}"</p>
+    </td>
+  {{/each}}
+</tbody>

--- a/app/templates/components/em-pagination.hbs
+++ b/app/templates/components/em-pagination.hbs
@@ -1,5 +1,2 @@
-<td colspan="6" class="pagination-cell">
-  <a class="btn pagination-link {{if hasPreviousPage 'enabled' 'disabled'}}" {{action 'previousPage'}}>Previous</a>
-
-  <a class="btn pagination-link {{if hasNextPage 'enabled' 'disabled'}}" {{action 'nextPage'}}>Next</a>
-</td>
+<a class="btn pagination-link {{if hasPreviousPage 'enabled' 'disabled'}}" {{action 'previousPage'}}>Previous</a>
+<a class="btn pagination-link {{if hasNextPage 'enabled' 'disabled'}}" {{action 'nextPage'}}>Next</a>

--- a/app/templates/packages/list.hbs
+++ b/app/templates/packages/list.hbs
@@ -8,19 +8,16 @@
   <div class="row">
     <div class="col-sm-12">
 
-      {{#liquid-bind page class="lf-slider" as |currentPage|}}
-        {{em-list
-          query=query
-          list=model
-          page=currentPage
-          limit=limit
-        }}
-      {{/liquid-bind}}
-
-      {{em-pagination
+      {{em-list
         list=model
-        page=page
-        limit=limit
+
+        meta=(hash 
+          query=query
+          page=page
+          limit=limit
+          packageCount=packageCount
+        )
+
         previous=(action 'previousPage')
         next=(action 'nextPage')
       }}

--- a/app/templates/packages/list.hbs
+++ b/app/templates/packages/list.hbs
@@ -7,9 +7,17 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
-       
-      {{em-list
-        query=query
+
+      {{#liquid-bind page class="lf-slider" as |currentPage|}}
+        {{em-list
+          query=query
+          list=model
+          page=currentPage
+          limit=limit
+        }}
+      {{/liquid-bind}}
+
+      {{em-pagination
         list=model
         page=page
         limit=limit

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -1,0 +1,26 @@
+const opts = { duration: 300, delay: 100, easing: 'easeInOutQuart' };
+const media = '(min-width: 768px)';
+
+// Only animate between page results if the distance between the pages is one.
+// This avoids animations occuring when the distance between pages is possibly more 
+// that one (i.e. clicking the logo).
+
+export default function(){
+  this.transition(
+    this.hasClass('lf-slider'),
+    this.media(media),
+    this.toValue(function(newPage, oldPage){
+      return newPage - 1 === oldPage;
+    }),
+    this.use('toLeft', opts)
+  );
+
+  this.transition(
+    this.hasClass('lf-slider'),
+    this.media(media),
+    this.toValue(function(newPage, oldPage){
+      return newPage + 1 === oldPage;
+    }),
+    this.use('toRight', opts)
+  );
+};

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -1,5 +1,4 @@
 const opts = { duration: 300, delay: 100, easing: 'easeInOutQuart' };
-const media = '(min-width: 768px)';
 
 // Only animate between page results if the distance between the pages is one.
 // This avoids animations occuring when the distance between pages is possibly more 
@@ -8,7 +7,6 @@ const media = '(min-width: 768px)';
 export default function(){
   this.transition(
     this.hasClass('lf-slider'),
-    this.media(media),
     this.toValue(function(newPage, oldPage){
       return newPage.meta.page - 1 === oldPage.meta.page;
     }),
@@ -17,7 +15,6 @@ export default function(){
 
   this.transition(
     this.hasClass('lf-slider'),
-    this.media(media),
     this.toValue(function(newPage, oldPage){
       return newPage.meta.page + 1 === oldPage.meta.page;
     }),

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -10,7 +10,7 @@ export default function(){
     this.hasClass('lf-slider'),
     this.media(media),
     this.toValue(function(newPage, oldPage){
-      return newPage - 1 === oldPage;
+      return newPage.meta.page - 1 === oldPage.meta.page;
     }),
     this.use('toLeft', opts)
   );
@@ -19,7 +19,7 @@ export default function(){
     this.hasClass('lf-slider'),
     this.media(media),
     this.toValue(function(newPage, oldPage){
-      return newPage + 1 === oldPage;
+      return newPage.meta.page + 1 === oldPage.meta.page;
     }),
     this.use('toRight', opts)
   );

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-moment": "7.3.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "2.12.0-beta.2",
+    "liquid-fire": "^0.27.1",
     "loader.js": "^4.0.10"
   }
 }

--- a/tests/unit/components/em-pagination-test.js
+++ b/tests/unit/components/em-pagination-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 
-moduleForComponent('em-pagination', 'Unit | Component | x pagination', {
+moduleForComponent('em-pagination', 'Unit | Component | em pagination', {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar'],
   unit: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,13 +1960,20 @@ ember-factory-for-polyfill@^1.1.0:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-getowner-polyfill@^1.1.0:
+ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.1.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.2.tgz#cdab739e89cc8f25af0f78735422df1a61193e92"
   dependencies:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
+
+ember-hash-helper-polyfill@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-hash-helper-polyfill/-/ember-hash-helper-polyfill-0.1.2.tgz#bc8ee6fa59e9541fce07d2cf4f263cf785e9e1db"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-cli-version-checker "^1.2.0"
 
 ember-inflector@^1.9.4:
   version "1.11.0"
@@ -3318,6 +3325,20 @@ linkify-it@~1.2.0:
   dependencies:
     uc.micro "^1.0.1"
 
+liquid-fire@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/liquid-fire/-/liquid-fire-0.27.1.tgz#bbcc1ac863a3dbdee1223b00c9457dbffb5d02b9"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^5.1.7"
+    ember-cli-htmlbars "^1.1.1"
+    ember-cli-version-checker "^1.1.6"
+    ember-getowner-polyfill "^1.1.1"
+    ember-hash-helper-polyfill "^0.1.2"
+    match-media "^0.2.0"
+    velocity-animate ">= 0.11.8"
+
 livereload-js@^2.2.0, livereload-js@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.2.2.tgz#6c87257e648ab475bc24ea257457edcc1f8d0bc2"
@@ -3614,6 +3635,10 @@ markdown-it@^8.2.0:
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.3"
+
+match-media@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/match-media/-/match-media-0.2.0.tgz#ea4e09742e7253cc7d7e1599ba627e0fa29fbc50"
 
 matcher-collection@^1.0.0, matcher-collection@^1.0.1:
   version "1.0.4"
@@ -5276,6 +5301,10 @@ validate-npm-package-license@^3.0.1:
 vary@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.0.tgz#e1e5affbbd16ae768dd2674394b9ad3022653140"
+
+"velocity-animate@>= 0.11.8":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.4.3.tgz#1d27a66afcc0cef73f8807b8c6253b94d214ad5a"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
This pull request adds a liquid-fire animation to the page navigation, because animations.
- Only animates between adjacent pages. (1 -> 2, not 1 -> 5 etc.)
- It purposely doesn't run on mobile (for perf reasons)