### PR TITLE
Allow opting out of fingerprinting to make benchmarking easier.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,6 +16,7 @@ module.exports = function(defaults) {
       extensions: ['js']
     },
     fingerprint: {
+      enabled: parseFlag('FINGERPRINT', env === 'production'),
       exclude: ['gravatar.jpg']
     }
   };


### PR DESCRIPTION
Doesn't really change anything for a default production build, but does allow folks to set `FINGERPRINT` to false when running `ember b -prod`.